### PR TITLE
Adding SHEBANG, to make it possible to use the script without '-> python <- <script.py>' 

### DIFF
--- a/liveTargetsFinder.py
+++ b/liveTargetsFinder.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import json
 import argparse
 import subprocess


### PR DESCRIPTION
Even though It may sound like a nitpick, adding the shebang now provides the possibility to create symlinks for scripts to the directory inside $PATH environment variable.
For example, without an added shebang, the interpreter cannot be resolved

![image](https://user-images.githubusercontent.com/32965886/99785786-ec186600-2b1d-11eb-96c0-70d9b735da41.png)

With shebang added, the issue is solved


